### PR TITLE
Run packages somewhat independently

### DIFF
--- a/tables-book/03-formatting-rendering.Rmd
+++ b/tables-book/03-formatting-rendering.Rmd
@@ -34,6 +34,9 @@ So for example a basic demographics table created with `rtables` via `tern` with
 title and footnotes would look as follows:
 
 ```{r,  comment=NA }
+resetSession()
+library(rtables)
+
 lyt <- basic_table(
   title = "Demographic Table - All Patients",
   subtitles = c("Cutoff Date: June 01, 2022", "Arm B received a placebo."),
@@ -53,7 +56,10 @@ Let's create first a flextable from an aggregation that
 will be used to illustrate the features.
 
 ```{r}
+resetSession()
+library(flextable)
 library(dplyr)
+
 z <- adsl |> 
   group_by(ARM, SEX) |>
   summarise(avg = mean(AGE), sd = sd(AGE)) |>
@@ -114,6 +120,9 @@ The `set_caption()` function in 'flextable' is the recommanded way to add
 captions. 
 
 ```{r}
+resetSession()
+library(flextable)
+
 flextable(head(cars)) |>
   set_caption(
     caption = "a caption",

--- a/tables-book/04-01-demographics.Rmd
+++ b/tables-book/04-01-demographics.Rmd
@@ -11,6 +11,9 @@ editor_options:
 Using `rtables` only:
 
 ```{r, comment= NA}
+resetSession()
+library(rtables)
+
 a_demo_num <- function(x) {
     in_rows(n = length(x),
             "Mean (SD)" = rcell(c(mean(x, na.rm = TRUE),
@@ -37,6 +40,7 @@ build_table(lyt, ex_adsl)
 Using `rtables` and `tern`
 
 ```{r, comment=NA}
+library(tern)
 lyt <- basic_table(title = "x.x: Study Subject Data",
                    subtitles= c("x.x.x: Demographic Characteristics",
                                 "Table x.x.x.x: Demographic Characteristics - Full Analysis Set"),
@@ -51,10 +55,13 @@ build_table(lyt, ex_adsl)
 ### gt
 
 ```{r, comment= NA}
+resetSession()
+library(gt)
 library(tidyverse)
 
 # We will use ex_adsl but will assign a unit to the Age column
 
+ex_adsl <- formatters::ex_adsl
 gt_adsl <- ex_adsl
 attr(gt_adsl$AGE, "units") <- "Years"
 
@@ -183,7 +190,11 @@ columns and how to format the contents.
 
 
 ```{r}
+resetSession()
+ex_adsl <- formatters::ex_adsl
+
 library(flextable)
+library(tidyverse)
 library(officer)
 
 set_flextable_defaults(

--- a/tables-book/04-02-events.Rmd
+++ b/tables-book/04-02-events.Rmd
@@ -9,7 +9,7 @@ editor_options:
 We will use the `ex_adae` data included within the `formatters` package
 
 ```{r, comment=NA}
-head(ex_adae)
+head(formatters::ex_adae)
 ```
 
 ### Adverse Events
@@ -21,6 +21,9 @@ head(ex_adae)
 Adverse Events by ID
 
 ```{r, comment=NA}
+resetSession()
+library(rtables)
+
 s_events_patients <- function(x, labelstr, .N_col) {
   in_rows(
     "Patients with at least one event" =
@@ -57,6 +60,10 @@ build_table(lyt, ex_adae, alt_counts_df = ex_adsl)
 #### flextable
 
 ```{r message=FALSE}
+resetSession()
+ex_adsl <- formatters::ex_adsl
+ex_adae <- formatters::ex_adae
+library(flextable)
 library(tidyr)
 library(dplyr)
 library(forcats)
@@ -136,6 +143,7 @@ tab <- tabulator(
   `nevents` = as_paragraph(n_events)
 )
 
+.ARM_COUNTS <- ARM_COUNTS
 ```
 
 flextable creation:

--- a/tables-book/04-04-kaplan-meier.Rmd
+++ b/tables-book/04-04-kaplan-meier.Rmd
@@ -9,6 +9,7 @@ editor_options:
 ### Data and models used throughout
 
 ```{r, comment=NA}
+resetSession()
 library(dplyr)
 library(tidyr)
 library(stringr)
@@ -36,12 +37,14 @@ surv_tbl <- as.data.frame(summary(survfit(Surv(AVAL, CNSR==0) ~ TRT01A,
     dplyr::mutate(TRT01A = factor(str_remove(row.names(.), "TRT01A="),
                                   levels = levels(adtte$TRT01A)),
                   ind = FALSE)
-
+.kmState <- currentState()
 ```
 
 ### rtables
 
 ```{r, comment=NA}
+resetSession(.kmState)
+library(rtables)
 
 cnsr_counter <- function(df, .var, .N_col) {
     x <- df[!duplicated(df$USUBJID), .var]
@@ -142,6 +145,8 @@ Our standard TTE table consists of (a derivation of) four main parts:
 4. Number of patients at risk at specified visits from Kaplan-Meier analysis (omitted here).
 
 ```{r descr_stats}
+resetSession(.kmState)
+library(gt)
 ### Subject Count with events
 
 ## surv_tbl calculated above
@@ -292,6 +297,12 @@ First we define named vectors that will be used later as
 labels for the table.
 
 ```{r}
+resetSession(.kmState)
+ARM_COUNTS <- .ARM_COUNTS # Restore from previous section
+
+library(flextable)
+library(tidyverse)
+
 # labels and notes ----
 description_labels <- c(SAE = "Number of subjects with serious adverse event", CENSOR_EVENTS = "Number of censored subjects",
   HAZARD_RATIO = "Hazard ratio", TTF_SAE = "Time to first adverse event")

--- a/tables-book/index.Rmd
+++ b/tables-book/index.Rmd
@@ -112,12 +112,33 @@ knitr::write_bib(c(
 ), 'packages.bib')
 ```
 
-
-You can then load the packages as follows:
+In each of the sections below, we will reset R to close to the
+present state
+at the start of the section, so readers can execute the demonstration
+code more or less independently of the other sections.  This is done using
+the functions defined below.  In your own documents, you wouldn't 
+need these resets.
 
 ```{r}
-library(gt)
-library(rtables)
-library(tern)
-library(flextable)
+# Get the list of attached packages and global environment objects
+currentState <- function() {
+  list(globals = ls(.GlobalEnv),
+       search = search())
+}
+
+resetSession <- function(state = .initial_state) {
+  # Clean up the search list
+  for (n in setdiff(search(), state$search)) {
+    detach(n, character.only = TRUE)
+  }
+  
+  # Clean up the global environment by deleting everything
+  # that wasn't there when `state` was constructed.
+  # Objects whose name starts with "." are not deleted.
+  
+  rm(list = setdiff(ls(.GlobalEnv), state$globals),
+     envir = .GlobalEnv)
+}
+.initial_state <- currentState()
 ```
+


### PR DESCRIPTION
I started adding the `tables` package to the book, but ran into a problem.  Since `tables` can work with `kableExtra`, I had `library(kableExtra)` in one of my code chunks.  But that broke `flextable`, because both `kableExtra` and `flextable` export a function named `footnote`.  When a later `flextable` chunk used `footnote()`, it failed because R found the one from `kableExtra` first.

A simple workaround for this is for me to use the `kableExtra::footnote` in my section instead of `library(kableExtra)`.  But this is a book about tables, so it's likely there will be further name clashes in the future if other packages are added.  This PR is an attempt at a more comprehensive solution.  At the start of each section that works with a new package, I've inserted a call to the new function `resetSession()`.  This reduces the search list to what it was at the start, so a new `library(rtables)` (for example) call is required.  It also removes any global variables that were created since the start, unless the name starts with a dot.

I think the reset could do more, e.g. it could restore the values of all the globals, but at present it doesn't do that, it assumes they stay unchanged.

A good side effect of this change is that readers of the book can treat each section as more or less self-contained.  (Not exactly:  the common initialization at the start is still needed.  But more self-contained than it was.)  Another good side effect is that the section order can be rearranged without breaking things too much.

A bad side effect is that package authors need to remember to call `resetSession()`, and to call `library(rtables)` (or whatever).