### PR TITLE
Improve reference list a bit by including the package version note.

### DIFF
--- a/tables-book/02-table-packages.Rmd
+++ b/tables-book/02-table-packages.Rmd
@@ -128,6 +128,6 @@ knitr::write_bib(c(
   "gt", "r2rtf", "rtables", "flextable", "tables", "tidytlg", "tfrmt"
 ), 'packages.bib')
 lines <- readLines("packages.bib")
-lines <- sub("^  note = \\{http", "  note = {R package},\n  url = {http", lines)
+lines <- sub("^  note = \\{R package", "  edition = {R package", lines)
 writeLines(lines, "packages.bib")
 ```


### PR DESCRIPTION
A bug in utils::citations() means this won't appear for packages that list 2 URLs in their DESCRIPTION, i.e. `rtables`, `tfrmt`, `flextable`.